### PR TITLE
Update dependency versions

### DIFF
--- a/.actions/build-linux-i686-w64-mingw32-gcc
+++ b/.actions/build-linux-i686-w64-mingw32-gcc
@@ -42,7 +42,7 @@ sudo make install_sw
 cd ..
 
 # Build and install zlib.
-git clone --depth=1 https://github.com/madler/zlib -b v1.2.12
+git clone --depth=1 https://github.com/madler/zlib -b v1.2.13
 cd zlib
 make -fwin32/Makefile.gcc PREFIX=i686-w64-mingw32-
 sudo make -fwin32/Makefile.gcc PREFIX=i686-w64-mingw32- DESTDIR=/fakeroot \

--- a/.actions/build-linux-openssl3-i686-w64-mingw32-gcc
+++ b/.actions/build-linux-openssl3-i686-w64-mingw32-gcc
@@ -43,7 +43,7 @@ sudo make install_sw
 cd ..
 
 # Build and install zlib.
-git clone --depth=1 https://github.com/madler/zlib -b v1.2.12
+git clone --depth=1 https://github.com/madler/zlib -b v1.2.13
 cd zlib
 make -fwin32/Makefile.gcc PREFIX=i686-w64-mingw32-
 sudo make -fwin32/Makefile.gcc PREFIX=i686-w64-mingw32- DESTDIR=/fakeroot \

--- a/.actions/fuzz-linux
+++ b/.actions/fuzz-linux
@@ -12,7 +12,7 @@ LIBCBOR_MSAN="memory"
 OPENSSL_URL="https://github.com/openssl/openssl"
 OPENSSL_TAG="OpenSSL_1_1_1q"
 ZLIB_URL="https://github.com/madler/zlib"
-ZLIB_TAG="v1.2.12"
+ZLIB_TAG="v1.2.13"
 ZLIB_ASAN="address alignment bounds undefined"
 ZLIB_MSAN="memory"
 FIDO2_ASAN="address bounds implicit-conversion leak pointer-compare pointer-subtract undefined"
@@ -65,7 +65,7 @@ cd -
 # zlib
 git clone --depth=1 "${ZLIB_URL}" -b "${ZLIB_TAG}"
 cd zlib
-CFLAGS="${ZLIB_CFLAGS}" LDFLAGS="${ZLIB_CFLAGS}" cc="$CC" ./configure \
+CFLAGS="${ZLIB_CFLAGS}" LDFLAGS="${ZLIB_CFLAGS}" ./configure \
     --prefix="${FAKEROOT}"
 make install
 cd -

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,7 +448,6 @@ endif()
 enable_testing()
 
 subdirs(src)
-subdirs(regress)
 if(BUILD_EXAMPLES)
 	subdirs(examples)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if(MSVC)
 	endif()
 	set(CBOR_LIBRARIES cbor)
 	set(ZLIB_LIBRARIES zlib1)
-	set(CRYPTO_LIBRARIES crypto-49)
+	set(CRYPTO_LIBRARIES crypto-50)
 	set(MSVC_DISABLED_WARNINGS_LIST
 		"C4152" # nonstandard extension used: function/data pointer
 			# conversion in expression;

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -230,7 +230,7 @@ try {
 	    ExitOnError
 	# Copy DLLs.
 	if ("${SHARED}" -eq "ON") {
-		"cbor.dll", "crypto-49.dll", "zlib1.dll" | `
+		"cbor.dll", "crypto-50.dll", "zlib1.dll" | `
 		    %{ Copy-Item "${PREFIX}\bin\$_" `
 		    -Destination "examples\${Config}" }
 	}

--- a/windows/const.ps1
+++ b/windows/const.ps1
@@ -7,7 +7,7 @@
 New-Variable -Name 'LIBRESSL_URL' `
     -Value 'https://fastly.cdn.openbsd.org/pub/OpenBSD/LibreSSL' `
     -Option Constant
-New-Variable -Name 'LIBRESSL' -Value 'libressl-3.5.3' -Option Constant
+New-Variable -Name 'LIBRESSL' -Value 'libressl-3.6.1' -Option Constant
 
 # libcbor coordinates.
 New-Variable -Name 'LIBCBOR' -Value 'libcbor-0.9.0' -Option Constant

--- a/windows/const.ps1
+++ b/windows/const.ps1
@@ -16,8 +16,8 @@ New-Variable -Name 'LIBCBOR_GIT' -Value 'https://github.com/pjk/libcbor' `
     -Option Constant
 
 # zlib coordinates.
-New-Variable -Name 'ZLIB' -Value 'zlib-1.2.12' -Option Constant
-New-Variable -Name 'ZLIB_BRANCH' -Value 'v1.2.12' -Option Constant
+New-Variable -Name 'ZLIB' -Value 'zlib-1.2.13' -Option Constant
+New-Variable -Name 'ZLIB_BRANCH' -Value 'v1.2.13' -Option Constant
 New-Variable -Name 'ZLIB_GIT' -Value 'https://github.com/madler/zlib' `
     -Option Constant
 

--- a/windows/ms_const.ps1
+++ b/windows/ms_const.ps1
@@ -3,8 +3,8 @@
 # license that can be found in the LICENSE file.
 
 # LibreSSL coordinates.
-New-Variable -Name 'LIBRESSL' -Value 'libressl-3.4.2' -Option Constant
-New-Variable -Name 'LIBRESSL_BIN_URL' -Value 'https://github.com/PowerShell/LibreSSL/releases/download/V3.4.2.0/LibreSSL.zip' -Option Constant
+New-Variable -Name 'LIBRESSL' -Value 'libressl-3.6.1' -Option Constant
+New-Variable -Name 'LIBRESSL_BIN_URL' -Value 'https://github.com/PowerShell/LibreSSL/releases/download/V3.6.1.0/LibreSSL.zip' -Option Constant
 
 # libcbor coordinates.
 New-Variable -Name 'LIBCBOR' -Value 'libcbor' -Option Constant
@@ -14,8 +14,8 @@ New-Variable -Name 'LIBCBOR_GIT' -Value 'https://github.com/PowerShell/libcbor' 
 
 # zlib coordinates.
 New-Variable -Name 'ZLIB' -Value 'zlib' -Option Constant
-New-Variable -Name 'ZLIB_BRANCH' -Value 'v1.2.11' -Option Constant
-New-Variable -Name 'ZLIB_BIN_URL' -Value 'https://github.com/PowerShell/ZLib/releases/download/V1.2.11/ZLib.zip' -Option Constant
+New-Variable -Name 'ZLIB_BRANCH' -Value 'v1.2.13' -Option Constant
+New-Variable -Name 'ZLIB_BIN_URL' -Value 'https://github.com/PowerShell/ZLib/releases/download/V1.2.13/ZLib.zip' -Option Constant
 
 # Work directories.
 New-Variable -Name 'BUILD' -Value "$PSScriptRoot\..\build" -Option Constant

--- a/windows/ms_release.ps1
+++ b/windows/ms_release.ps1
@@ -7,7 +7,7 @@ $Architectures = @('x64', 'Win32', 'ARM64', 'ARM')
 $InstallPrefixes =  @('Win64', 'Win32', 'ARM64', 'ARM')
 $Types = @('static')
 $Config = 'Release'
-$LibCrypto = '46'
+$LibCrypto = '50'
 $SDK = '142'
 
 . "$PSScriptRoot\ms_const.ps1"

--- a/windows/release.ps1
+++ b/windows/release.ps1
@@ -8,7 +8,7 @@ $Architectures = @('x64', 'Win32', 'ARM64', 'ARM')
 $InstallPrefixes =  @('Win64', 'Win32', 'ARM64', 'ARM')
 $Types = @('dynamic', 'static')
 $Config = 'Release'
-$LibCrypto = '49'
+$LibCrypto = '50'
 $SDK = '143'
 
 . "$PSScriptRoot\const.ps1"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- cherry-pick: bump libressl to 3.6.1
- cherry-pick: bump zlib to 1.2.13
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
LibreSSL and ZLib versions need to be the same for both LibFido2 & OpenSSH