### PR TITLE
Revert "compile with LibreSSL 3.5.3"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if(MSVC)
 	endif()
 	set(CBOR_LIBRARIES cbor)
 	set(ZLIB_LIBRARIES zlib1)
-	set(CRYPTO_LIBRARIES crypto-49)
+	set(CRYPTO_LIBRARIES crypto-50)
 	set(MSVC_DISABLED_WARNINGS_LIST
 		"C4152" # nonstandard extension used: function/data pointer
 			# conversion in expression;

--- a/windows/ms_const.ps1
+++ b/windows/ms_const.ps1
@@ -3,8 +3,8 @@
 # license that can be found in the LICENSE file.
 
 # LibreSSL coordinates.
-New-Variable -Name 'LIBRESSL' -Value 'libressl-3.5.3' -Option Constant
-New-Variable -Name 'LIBRESSL_BIN_URL' -Value 'https://github.com/PowerShell/LibreSSL/releases/download/V3.5.3.0/LibreSSL.zip' -Option Constant
+New-Variable -Name 'LIBRESSL' -Value 'libressl-3.6.1' -Option Constant
+New-Variable -Name 'LIBRESSL_BIN_URL' -Value 'https://github.com/PowerShell/LibreSSL/releases/download/V3.6.1.0/LibreSSL.zip' -Option Constant
 
 # libcbor coordinates.
 New-Variable -Name 'LIBCBOR' -Value 'libcbor' -Option Constant

--- a/windows/ms_release.ps1
+++ b/windows/ms_release.ps1
@@ -7,7 +7,7 @@ $Architectures = @('x64', 'Win32', 'ARM64', 'ARM')
 $InstallPrefixes =  @('Win64', 'Win32', 'ARM64', 'ARM')
 $Types = @('static')
 $Config = 'Release'
-$LibCrypto = '49'
+$LibCrypto = '50'
 $SDK = '142'
 
 . "$PSScriptRoot\ms_const.ps1"


### PR DESCRIPTION
Reverts PowerShell/libfido2#8 so that we go back to compiling with LibreSSL 3.6.1